### PR TITLE
Improve error response when resource is unavailable

### DIFF
--- a/internal/webservice/response.go
+++ b/internal/webservice/response.go
@@ -43,3 +43,17 @@ func badRequestResponse(req *restful.Request, resp *restful.Response, err error)
 		log.Logger.Errorf("could not write error response: %v", err)
 	}
 }
+
+func notFoundResponse(req *restful.Request, resp *restful.Response, err error) {
+	log.Logger.Errorf("error processing request for %s: %v", req.Request.URL.Path, err)
+	problemDetails := ProblemDetails{
+		Type:     "about:blank",
+		Title:    "Not Found",
+		Status:   http.StatusNotFound,
+		Detail:   err.Error(),
+		Instance: req.Request.URL.Path,
+	}
+	if err := resp.WriteHeaderAndJson(http.StatusNotFound, problemDetails, "application/problem+json"); err != nil {
+		log.Logger.Errorf("could not write error response: %v", err)
+	}
+}

--- a/internal/webservice/response.go
+++ b/internal/webservice/response.go
@@ -17,7 +17,6 @@ func jsonResponse(response *restful.Response, data any) {
 
 // errorResponse writes an RFC7807 Problem error response to the response writer.
 func errorResponse(req *restful.Request, resp *restful.Response, err error) {
-	log.Logger.Errorf("error processing request for %s: %v", req.Request.URL.Path, err)
 	problemDetails := ProblemDetails{
 		Type:     "about:blank",
 		Title:    "Internal Server Error",
@@ -31,7 +30,6 @@ func errorResponse(req *restful.Request, resp *restful.Response, err error) {
 }
 
 func badRequestResponse(req *restful.Request, resp *restful.Response, err error) {
-	log.Logger.Errorf("error processing request for %s: %v", req.Request.URL.Path, err)
 	problemDetails := ProblemDetails{
 		Type:     "about:blank",
 		Title:    "Bad Request",
@@ -45,7 +43,6 @@ func badRequestResponse(req *restful.Request, resp *restful.Response, err error)
 }
 
 func notFoundResponse(req *restful.Request, resp *restful.Response, err error) {
-	log.Logger.Errorf("error processing request for %s: %v", req.Request.URL.Path, err)
 	problemDetails := ProblemDetails{
 		Type:     "about:blank",
 		Title:    "Not Found",

--- a/internal/webservice/routes.go
+++ b/internal/webservice/routes.go
@@ -271,6 +271,10 @@ func (ws *WebService) getPartitions(req *restful.Request, resp *restful.Response
 		errorResponse(req, resp, err)
 		return
 	}
+	if partitions == nil {
+		notFoundResponse(req, resp, fmt.Errorf("no partitions found"))
+		return
+	}
 	jsonResponse(resp, partitions)
 }
 
@@ -280,6 +284,10 @@ func (ws *WebService) getQueuesPerPartition(req *restful.Request, resp *restful.
 	queues, err := ws.repository.GetQueuesInPartition(ctx, partitionID)
 	if err != nil {
 		errorResponse(req, resp, err)
+		return
+	}
+	if queues == nil {
+		notFoundResponse(req, resp, fmt.Errorf("no queues found"))
 		return
 	}
 	root, err := buildPartitionQueueTrees(ctx, queues)
@@ -351,6 +359,10 @@ func (ws *WebService) getAppsPerPartitionPerQueue(req *restful.Request, resp *re
 		errorResponse(req, resp, err)
 		return
 	}
+	if apps == nil {
+		notFoundResponse(req, resp, fmt.Errorf("no applications found"))
+		return
+	}
 
 	jsonResponse(resp, apps)
 }
@@ -366,6 +378,10 @@ func (ws *WebService) getNodesPerPartition(req *restful.Request, resp *restful.R
 	nodes, err := ws.repository.GetNodesPerPartition(ctx, partitionID, *filters)
 	if err != nil {
 		errorResponse(req, resp, err)
+		return
+	}
+	if nodes == nil {
+		notFoundResponse(req, resp, fmt.Errorf("no nodes found"))
 		return
 	}
 	jsonResponse(resp, nodes)
@@ -384,6 +400,10 @@ func (ws *WebService) getAppsHistory(req *restful.Request, resp *restful.Respons
 		errorResponse(req, resp, err)
 		return
 	}
+	if appsHistory == nil {
+		notFoundResponse(req, resp, fmt.Errorf("no applications history found"))
+		return
+	}
 	jsonResponse(resp, appsHistory)
 }
 
@@ -397,6 +417,10 @@ func (ws *WebService) getContainersHistory(req *restful.Request, resp *restful.R
 	containersHistory, err := ws.repository.GetContainersHistory(ctx, *filters)
 	if err != nil {
 		errorResponse(req, resp, err)
+		return
+	}
+	if containersHistory == nil {
+		notFoundResponse(req, resp, fmt.Errorf("no containers history found"))
 		return
 	}
 	jsonResponse(resp, containersHistory)

--- a/internal/webservice/routes_test.go
+++ b/internal/webservice/routes_test.go
@@ -2,15 +2,19 @@ package webservice
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/G-Research/unicorn-history-server/internal/database/repository"
 	"github.com/G-Research/yunikorn-core/pkg/webservice/dao"
+	"github.com/emicklei/go-restful/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/G-Research/unicorn-history-server/internal/config"
 	"github.com/G-Research/unicorn-history-server/internal/model"
@@ -210,6 +214,67 @@ func TestBuildPartitionQueueTree(t *testing.T) {
 			got, err := buildPartitionQueueTrees(context.TODO(), tc.queues)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGetAppsPerPartitionPerQueue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepo := repository.NewMockRepository(ctrl)
+
+	tests := []struct {
+		name           string
+		partitionID    string
+		queueID        string
+		expectedApps   []*model.Application
+		expectedStatus int
+	}{
+		{
+			name:        "Apps found",
+			partitionID: "1",
+			queueID:     "1",
+			expectedApps: []*model.Application{
+				{
+					Metadata: model.Metadata{
+						CreatedAtNano: time.Now().UnixNano(),
+					},
+					ApplicationDAOInfo: dao.ApplicationDAOInfo{
+						ID:            "1",
+						ApplicationID: "app1",
+						Partition:     "default",
+						PartitionID:   "1",
+						QueueID:       util.ToPtr("1"),
+						QueueName:     "root.default",
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "No apps found",
+			partitionID:    "1",
+			queueID:        "1",
+			expectedApps:   nil,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo.EXPECT().
+				GetAppsPerPartitionPerQueue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(tt.expectedApps, nil)
+
+			ws := &WebService{repository: mockRepo}
+
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/partitions/%s/queues/%s/apps", tt.partitionID, tt.queueID), nil)
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+
+			ws.getAppsPerPartitionPerQueue(restful.NewRequest(req), restful.NewResponse(rr))
+			require.Equal(t, tt.expectedStatus, rr.Code)
 		})
 	}
 }

--- a/internal/yunikorn/sync.go
+++ b/internal/yunikorn/sync.go
@@ -28,7 +28,6 @@ func (s *Service) syncPartitions(ctx context.Context, partitions []*dao.Partitio
 	for _, p := range partitions {
 		current, err := s.repo.GetPartitionByID(ctx, p.ID)
 		if err != nil {
-			fmt.Printf("Error getting partition: %v\n", err)
 			partition := &model.Partition{
 				Metadata: model.Metadata{
 					CreatedAtNano: now,


### PR DESCRIPTION
Closes #357  

- [x] Removed unnecessary `print` statement for errors.  
- [x] Updated application endpoint to include a standard 404 response when a resource is not found.  
- [x] Updated other endpoints in the web service to follow a similar approach by adding a standard 404 response.
