### PR TITLE
Denis coric/prod env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -613,9 +613,11 @@ $(K6): bin/tooling
 node: $(NODE_DIR) ## download and setup node locally if necessary.
 $(NODE_DIR): bin/tooling
 	if [ ! -d $(NODE_DIR) ]; then \
-		mkdir -p $(NODE_DIR) && \
-		curl -fsSL https://nodejs.org/dist/v$(subst x,,$(NODE_VERSION))/node-v$(subst x,,$(NODE_VERSION))-$(OS)-$(ARCH).tar.gz | tar -xz --strip-components=1 -C $(NODE_DIR) && \
-		$(NODE_DIR)/bin/corepack enable && \
-		$(NODE_DIR)/bin/npm install -g pnpm@9 ; \
-	fi
+		mkdir -p $(NODE_DIR) ; \
+	fi ; \
+	NODE_ARCH="$$(if [ "$$(uname -m)" = "x86_64" ]; then echo "x64"; elif [ "$$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "$$(uname -m)"; fi)" ; \
+	echo "Downloading node $(NODE_VERSION) for $(OS)-$${NODE_ARCH}: https://nodejs.org/dist/v$(subst x,,$(NODE_VERSION))/node-v$(subst x,,$(NODE_VERSION))-$(OS)-$${NODE_ARCH}.tar.gz" ; \
+	curl -fsSL https://nodejs.org/dist/v$(subst x,,$(NODE_VERSION))/node-v$(subst x,,$(NODE_VERSION))-$(OS)-$${NODE_ARCH}.tar.gz | tar -xz --strip-components=1 -C $(NODE_DIR) ; \
+	PATH=$(NODE_DIR)/bin:$$PATH $(NODE_DIR)/bin/corepack enable && \
+	PATH=$(NODE_DIR)/bin:$$PATH $(NODE_DIR)/bin/corepack prepare pnpm@$(PNPM_VERSION) --activate
 

--- a/web/package.json
+++ b/web/package.json
@@ -51,7 +51,7 @@
     "ngx-build-plus": "^18.0.0",
     "prettier": "^3.3.3",
     "typescript": "5.5.4",
-    "yunikorn-web": "github:G-Research/yunikorn-web#denis-coric/dynamic-env"
+    "yunikorn-web": "github:G-Research/yunikorn-web"
   },
   "engines": {
     "pnpm": "9",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,6 @@
     "run:all": "node node_modules/@angular-architects/module-federation/src/server/mf-dev-server.js",
     "setenv": "npx --yes ts-node ./src/environments/setEnvironmentVariables.ts",
     "setenv:prod": "npx --yes ts-node ./src/environments/setEnvironmentVariables.ts prod",
-    "prebuild:prod": "pnpm set-env-vars",
     "start:json-server": "json-server --watch mock-server/db.json --config mock-server/server.json",
     "prettify": "prettier --config ./.prettierrc --write 'src/**/*.{js,ts,json,css,scss,md,html}'"
   },
@@ -52,11 +51,11 @@
     "ngx-build-plus": "^18.0.0",
     "prettier": "^3.3.3",
     "typescript": "5.5.4",
-    "yunikorn-web": "github:G-Research/yunikorn-web"
+    "yunikorn-web": "github:G-Research/yunikorn-web#denis-coric/dynamic-env"
   },
   "engines": {
     "pnpm": "9",
     "node": "22"
   },
-  "packageManager": "pnpm@9"
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: 5.5.4
         version: 5.5.4
       yunikorn-web:
-        specifier: github:G-Research/yunikorn-web
-        version: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/8628b4f8ee86e55e5c5089da0a7bf04bd86443fd(encoding@0.1.13)
+        specifier: github:G-Research/yunikorn-web#denis-coric/dynamic-env
+        version: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a(encoding@0.1.13)
 
 packages:
 
@@ -4595,8 +4595,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/8628b4f8ee86e55e5c5089da0a7bf04bd86443fd:
-    resolution: {tarball: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/8628b4f8ee86e55e5c5089da0a7bf04bd86443fd}
+  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a:
+    resolution: {tarball: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a}
     version: 0.0.0
     engines: {node: '22', pnpm: '9'}
 
@@ -9485,7 +9485,7 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/8628b4f8ee86e55e5c5089da0a7bf04bd86443fd(encoding@0.1.13):
+  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a(encoding@0.1.13):
     dependencies:
       '@angular-architects/module-federation': 18.0.6(@angular/common@18.2.13(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))(encoding@0.1.13)
       '@angular/animations': 18.2.13(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         version: 5.5.4
       yunikorn-web:
         specifier: github:G-Research/yunikorn-web#denis-coric/dynamic-env
-        version: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a(encoding@0.1.13)
+        version: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb(encoding@0.1.13)
 
 packages:
 
@@ -4595,8 +4595,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a:
-    resolution: {tarball: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a}
+  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb:
+    resolution: {tarball: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb}
     version: 0.0.0
     engines: {node: '22', pnpm: '9'}
 
@@ -9485,7 +9485,7 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/fe44c12687731a878bd35eb1cca9c36ba36ec73a(encoding@0.1.13):
+  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb(encoding@0.1.13):
     dependencies:
       '@angular-architects/module-federation': 18.0.6(@angular/common@18.2.13(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))(encoding@0.1.13)
       '@angular/animations': 18.2.13(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: 5.5.4
         version: 5.5.4
       yunikorn-web:
-        specifier: github:G-Research/yunikorn-web#denis-coric/dynamic-env
-        version: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb(encoding@0.1.13)
+        specifier: github:G-Research/yunikorn-web
+        version: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/17606a8bd534c62bcef7352127bb133dc092d246(encoding@0.1.13)
 
 packages:
 
@@ -4595,8 +4595,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb:
-    resolution: {tarball: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb}
+  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/17606a8bd534c62bcef7352127bb133dc092d246:
+    resolution: {tarball: https://codeload.github.com/G-Research/yunikorn-web/tar.gz/17606a8bd534c62bcef7352127bb133dc092d246}
     version: 0.0.0
     engines: {node: '22', pnpm: '9'}
 
@@ -9485,7 +9485,7 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/c2cb0b875340be6dd563bc7a18730fb1641e2deb(encoding@0.1.13):
+  yunikorn-web@https://codeload.github.com/G-Research/yunikorn-web/tar.gz/17606a8bd534c62bcef7352127bb133dc092d246(encoding@0.1.13):
     dependencies:
       '@angular-architects/module-federation': 18.0.6(@angular/common@18.2.13(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))(encoding@0.1.13)
       '@angular/animations': 18.2.13(@angular/core@18.2.13(rxjs@7.8.1)(zone.js@0.14.10))

--- a/web/src/app/services/envconfig/envconfig.service.ts
+++ b/web/src/app/services/envconfig/envconfig.service.ts
@@ -48,34 +48,43 @@ export class EnvConfigService {
   }
 
   loadEnvConfig(): Promise<void> {
+    if (environment.production) {
+      console.log('environment.production', environment.production);
+      return Promise.resolve();
+    }
+
     return new Promise((resolve) => {
-      this.httpClient.get<EnvConfig>(ENV_CONFIG_JSON_URL).subscribe((data) => {
-        this.envConfig = data;
-        resolve();
+      this.httpClient.get<EnvConfig>(ENV_CONFIG_JSON_URL).subscribe({
+        next: (data) => {
+          this.envConfig = data;
+          resolve();
+        },
+        error: () => {
+          console.warn('Failed to load envconfig.json, using default values');
+          resolve();
+        },
       });
     });
   }
 
   getYuniKornWebAddress() {
-    console.log('environment.production', environment.production);
     if (!environment.production) {
       return `${this.envConfig.yunikornApiURL}/api`;
     }
-
     return `${this.uiProtocol}//${this.uiHostname}:${this.uiPort}/api`;
   }
 
   getUHSWebAddress() {
-    console.log('environment.production', environment.production);
-
     if (!environment.production) {
       return `${this.envConfig.uhsApiURL}/api`;
     }
-
     return `${this.uiProtocol}//${this.uiHostname}:${this.uiPort}/api`;
   }
 
   getExternalLogsBaseUrl() {
-    return this.envConfig.externalLogsURL || null;
+    if (!environment.production) {
+      return this.envConfig.externalLogsURL || null;
+    }
+    return null;
   }
 }

--- a/web/src/app/services/envconfig/envconfig.service.ts
+++ b/web/src/app/services/envconfig/envconfig.service.ts
@@ -20,6 +20,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { EnvConfig } from '@app/models/envconfig.model';
+import { environment } from 'src/environments/environment';
 
 const ENV_CONFIG_JSON_URL = './assets/config/envconfig.json';
 
@@ -56,15 +57,18 @@ export class EnvConfigService {
   }
 
   getYuniKornWebAddress() {
-    if (this.envConfig.yunikornApiURL) {
-      return `${this.envConfig.yunikornApiURL}/ws`;
+    console.log('environment.production', environment.production);
+    if (!environment.production) {
+      return `${this.envConfig.yunikornApiURL}/api`;
     }
 
-    return `${this.uiProtocol}//${this.uiHostname}:${this.uiPort}/ws`;
+    return `${this.uiProtocol}//${this.uiHostname}:${this.uiPort}/api`;
   }
 
   getUHSWebAddress() {
-    if (this.envConfig.uhsApiURL) {
+    console.log('environment.production', environment.production);
+
+    if (!environment.production) {
       return `${this.envConfig.uhsApiURL}/api`;
     }
 

--- a/web/src/assets/config/envconfig.json
+++ b/web/src/assets/config/envconfig.json
@@ -1,6 +1,6 @@
 {
-  "localUhsComponentsWebAddress": "http://127.0.0.1:8989",
+  "localUhsComponentsWebAddress": "http://localhost:8989",
   "externalLogsURL": "https://logs.example.com?token=abc123&applicationId=",
-  "yunikornApiURL": "http://127.0.0.1:30001",
-  "uhsApiURL": "http://127.0.0.1:8989"
+  "yunikornApiURL": "http://localhost:30001",
+  "uhsApiURL": "http://localhost:8989"
 }

--- a/web/src/assets/config/envconfig.json
+++ b/web/src/assets/config/envconfig.json
@@ -1,6 +1,6 @@
 {
-  "localUhsComponentsWebAddress": "http://localhost:3100",
+  "localUhsComponentsWebAddress": "http://127.0.0.1:8989",
   "externalLogsURL": "https://logs.example.com?token=abc123&applicationId=",
-  "yunikornApiURL": "http://localhost:30001",
-  "uhsApiURL": "http://localhost:8989"
+  "yunikornApiURL": "http://127.0.0.1:30001",
+  "uhsApiURL": "http://127.0.0.1:8989"
 }

--- a/web/src/environments/environment.ts
+++ b/web/src/environments/environment.ts
@@ -16,22 +16,10 @@
  * limitations under the License.
  */
 
-// This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
-// The list of file replacements can be found in `angular.json`.
-
 export const environment = {
-  production: false,
+  production: true,
   externalLogsURL: '',
   yunikornApiURL: '',
   uhsApiURL: '',
+  localUhsComponentsWebAddress: '',
 };
-
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
This pull request is altering how UHS & YK Web use environment configuration.

- If production is active on build-time, both web apps will use information from the current window (path and port) to target the UHS API directly
- Override is still possible for development purposes (production flag set to false)

This change aims to remove hardcoded dependencies and paths on UHS/YK Web and allow deployment flexibility.