### PR TITLE
Migrated web build to Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ endif
 
 .PHONY: docker-build
 docker-build: OS=linux
-docker-build: bin/docker clean build web-build ## build docker image using buildx.
+docker-build: bin/docker clean build ## build docker image using buildx.
 	echo "Building docker image for linux/$(ARCH)"
 	docker buildx build    				     			 \
 		--file build/unicorn-history-server/Dockerfile   \
@@ -525,7 +525,7 @@ patch-yunikorn-service: ## patch yunikorn service to expose it as NodePort (yuni
 ##@ Build Dependencies
 
 .PHONY: install-tools
-install-tools: golangci-lint gotestsum $(CLUSTER_MGR) helm yq node ## install development tools.
+install-tools: golangci-lint gotestsum $(CLUSTER_MGR) helm yq ## install development tools.
 
 GOTESTSUM ?= $(LOCALBIN_TOOLING)/gotestsum
 GOTESTSUM_VERSION ?= v1.11.0

--- a/build/unicorn-history-server/Dockerfile
+++ b/build/unicorn-history-server/Dockerfile
@@ -1,13 +1,38 @@
+ARG NODE_VERSION=22
 ARG ALPINE_VERSION=3.20
+
+FROM node:${NODE_VERSION} AS uhs-web
+
+COPY web /build/src
+
+WORKDIR /build/src
+
+RUN npm install -g pnpm            && \
+    pnpm install                   && \
+    pnpm run build:prod
+
+FROM node:${NODE_VERSION} AS yunikorn-web
+
+COPY --from=uhs-web /build/src/node_modules/yunikorn-web /build/src
+RUN rm -rf /build/src/yunikorn-web/node_modules
+
+WORKDIR /build/src
+
+RUN npm install -g pnpm            && \
+    pnpm install                   && \
+    pnpm run build:prod
+
 
 FROM alpine:${ALPINE_VERSION}
 
-COPY assets /app/assets
+COPY --from=uhs-web /build/assets /app/assets
+COPY --from=yunikorn-web /build/src/dist/yunikorn-web /app/assets
 COPY bin/app/unicorn-history-server /app/unicorn-history-server
 COPY migrations /app/migrations
 COPY config/unicorn-history-server/config.yml /app/config.yml
 
 WORKDIR /app
+
 
 ENTRYPOINT ["/app/unicorn-history-server"]
 CMD ["--config", "config.yml"]

--- a/build/unicorn-history-server/Dockerfile
+++ b/build/unicorn-history-server/Dockerfile
@@ -11,22 +11,17 @@ RUN npm install -g pnpm            && \
     pnpm install                   && \
     pnpm run build:prod
 
-FROM node:${NODE_VERSION} AS yunikorn-web
+# Install yunikorn-web
+RUN git clone https://github.com/G-Research/yunikorn-web.git /build/src/yunikorn-web
 
-COPY --from=uhs-web /build/src/node_modules/yunikorn-web /build/src
-RUN rm -rf /build/src/yunikorn-web/node_modules
-
-WORKDIR /build/src
-
-RUN npm install -g pnpm            && \
-    pnpm install                   && \
+RUN cd /build/src/yunikorn-web && \
+    pnpm install && \
     pnpm run build:prod
-
 
 FROM alpine:${ALPINE_VERSION}
 
 COPY --from=uhs-web /build/assets /app/assets
-COPY --from=yunikorn-web /build/src/dist/yunikorn-web /app/assets
+COPY --from=uhs-web /build/src/yunikorn-web/dist/yunikorn-web /app/assets
 COPY bin/app/unicorn-history-server /app/unicorn-history-server
 COPY migrations /app/migrations
 COPY config/unicorn-history-server/config.yml /app/config.yml

--- a/build/unicorn-history-server/Dockerfile
+++ b/build/unicorn-history-server/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install -g pnpm            && \
     pnpm install                   && \
     pnpm run build:prod
 
-# Install yunikorn-web
+# Build yunikorn-web
 RUN git clone https://github.com/G-Research/yunikorn-web.git /build/src/yunikorn-web
 
 RUN cd /build/src/yunikorn-web && \

--- a/web/package.json
+++ b/web/package.json
@@ -50,8 +50,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "ngx-build-plus": "^18.0.0",
     "prettier": "^3.3.3",
-    "typescript": "5.5.4",
-    "yunikorn-web": "github:G-Research/yunikorn-web"
+    "typescript": "5.5.4"
   },
   "engines": {
     "pnpm": "9",


### PR DESCRIPTION
Changes in this PR:
- The build process for the web is moved to Dockerfile.
- `make web-build` is kept for local development and testing.
- `make install-tools` will not install node dependencies, but if `make web-build` is run, node dependencies will be installed